### PR TITLE
Add new tool: caffe_output_filter

### DIFF
--- a/caffe_cn_tools/caffe_output_filter.sh
+++ b/caffe_cn_tools/caffe_output_filter.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# This script is used to extract loss or accuracy values from the outputs of Caffe.
+# Usage:
+# caffe_output_filter.sh [train|test] [loss|top1|top5] [file]
+# -----------
+show_usage () {
+echo "
+********************************************
+This script is used to extract loss or accuracy values from the outputs of Caffe.
+
+Usage: $0 <option(s)> SOURCE
+caffe_output_filter.sh [<train|test>] [<loss|top1|top5>] [file].
+Options:
+	train|test: specify the stage of CNN.
+	loss|top1|top5: extract loss or accuracy.
+	file: read from a file or the standard input.
+Examples: 
+	./caffe_output_filter.sh train top1 caffe_output.txt
+	cat caffe_output.txt | ./caffe_output_filter.sh test top5
+	build/tools/caffe train --solver solver.prototxt |& ./caffe_output_filter.sh test top5 
+********************************************"
+}
+
+if [ "$1" = "train" ];
+then
+	phase=Train
+elif [ "$1" = "test" ]
+then
+	phase=Test
+else
+	show_usage
+	exit 1
+fi
+
+if [ "$2" = "loss" ];
+then
+	obj=0
+elif [ "$2" = "top1" ]
+then
+	obj=1
+elif [ "$2" = "top5" ]
+then
+	obj=2
+else
+	show_usage
+	exit 1
+fi
+
+# if [ -z $3 ];
+# then
+# 	show_usage
+# 	exit 1
+# elif [ -f $3 ];
+# then
+# 	log=$3
+# else
+# 	show_usage
+# 	exit 1
+# fi
+
+while read line
+do
+	grep --line-buffered -o "${phase} net output #${obj}.*" | cut -d " " -f 7
+done < "${3:-/dev/stdin}"


### PR DESCRIPTION
## 简介

`caffe_output_filter` 可提取 `Caffe` 日志里损失和精度的数值，以供其他程序使用。
## 使用方法

```
caffe_output_filter.sh [<train|test>] [<loss|top1|top5>] [file].
```

如果不指定 Caffe 日志文件，就从标准输入里读取数据
## 例子

从 `Caffe` 日志里读取数据，并输出 训练 `top-1` 精度。

```
./caffe_output_filter.sh train top1 caffe_output.txt
```

通过管道，从标准输入中读取数据，并提取 测试 `top-5` 精度。

```
cat caffe_output.txt | ./caffe_output_filter.sh test top5
```

一边训练，一遍提取测试 `top-1` 精度。

```
build/tools/caffe train --solver solver.prototxt |& ./caffe_output_filter.sh test top1
```
