### PR TITLE
添加对 Anaconda Python 3.5 的支持

### DIFF
--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -63,17 +63,24 @@ BLAS := atlas
 # We need to be able to find Python.h and numpy/arrayobject.h.
 PYTHON_INCLUDE := /usr/include/python2.7 \
 		/usr/lib/python2.7/dist-packages/numpy/core/include
-# Anaconda Python distribution is quite popular. Include path:
-# Verify anaconda location, sometimes it's in root.
-# ANACONDA_HOME := $(HOME)/anaconda
-# PYTHON_INCLUDE := $(ANACONDA_HOME)/include \
-		# $(ANACONDA_HOME)/include/python2.7 \
-		# $(ANACONDA_HOME)/lib/python2.7/site-packages/numpy/core/include \
-
 # Uncomment to use Python 3 (default is Python 2)
 # PYTHON_LIBRARIES := boost_python3 python3.5m
 # PYTHON_INCLUDE := /usr/include/python3.5m \
 #                 /usr/lib/python3.5/dist-packages/numpy/core/include
+# 
+# Anaconda Python distribution is quite popular. Include path:
+# Verify anaconda location, sometimes it's in root.
+# ANACONDA_HOME := $(HOME)/anaconda
+# Anaconda for python2.7:
+# PYTHON_INCLUDE := $(ANACONDA_HOME)/include \
+				# $(ANACONDA_HOME)/include/python2.7 \
+				# $(ANACONDA_HOME)/lib/python2.7/site-packages/numpy/core/include 
+# Uncomment PYTHON_INCLUDE below to use Anaconda python3
+# Anaconda for python 3:
+# PYTHON_LIBRARIES := boost_python3 python3.5m
+# PYTHON_INCLUDE := $(ANACONDA_HOME)/include \
+				# $(ANACONDA_HOME)/include/python3.5m \
+        		# $(ANACONDA_HOME)/lib/python3.5/site-packages/numpy/core/include
 
 # We need to be able to find libpythonX.X.so or .dylib.
 PYTHON_LIB := /usr/lib


### PR DESCRIPTION
目前的 `Makefile.config` 只支持官方的 `Python 3`，不支持 `Anaconda Python 3`。所以我在 `PYTHON_INCLUDE` 里加了些路径来支持用 `Anaconda Python 3.5` 编译 `python` 接口。

`caffe` 支持 `Python 3.5` 的编译方法，官方 python 和 ananconda python 均试用 

1) 下载 Anaconda3-2.5.0-Linux-x86_64.sh并安装
2) 下载 `protobuf 3.0 beta2` 的 c++ 版本 python 版本，然后手动编译并安装.
3) 运行 `sudo apt-get install libboost1.55-all-dev`, 安装 libboost1.55，然后再做一个软链接

```
sudo ln -s /usr/lib/x86_64-linux-gnu/libboost_python-py33.so.1.55.0 /usr/local/lib/libboost_python3.so
```

4) 然后在用这个 PR 的 `Makefile.config` 编译就行了
